### PR TITLE
fix: fix index snippet not executing

### DIFF
--- a/index.org
+++ b/index.org
@@ -166,7 +166,7 @@
 
 #+HTML_HEAD: <style>.src { display: none; }</style>
 #+caption: 統計情報。ビルド時に実行される
-#+begin_src bash :results raw
+#+begin_src shell :results raw
   file_changed_count_day() {
       datestr_past=$1
       datestr_future=$2


### PR DESCRIPTION
`Evaluation of this bash code block is disabled.` ?